### PR TITLE
update README to correct page size bytes vs words

### DIFF
--- a/README
+++ b/README
@@ -33,4 +33,4 @@ Producing a SysEx file from a firmware .hex
 
 python tools/hex2sysex/hex2sysex.py --syx -o firmware.syx firmware.hex
 
-Check python tools/hex2sysex/hex2sysex.py -help for more options. In particular, you can change the page size which is configured, by default, to 128 bytes (ATMega644p and 1284p). To know the page size (in words) of a specific device, look up the value of SPM_PAGE_SIZE.
+Check python tools/hex2sysex/hex2sysex.py -help for more options. In particular, you can change the page size which is configured, by default, to 128 words (256 bytes) (ATMega644p and 1284p). To know the page size (in words) of a specific device, look up the value of SPM_PAGESIZE, which is in bytes, and divide by 2.


### PR DESCRIPTION
Hi,

SPM_PAGESIZE is in bytes. Maybe it used to be in words, but now it is in bytes. You can see that here:

http://www.atmel.com/webdoc/avrlibcreferencemanual/group__avr__io.html

Furthermore, your examples have flash page sizes of 128 words = 256 bytes, not 128 bytes, as written here. And your Python code defaults to 128 words. This wording mistake in the README threw me off for a while because I was working with an ATMega 328PB and that uses a 128 byte = 64 word page size.  Your code wasn't working and I had to do some debugging to realize that it was just the SysX file that wasn't getting encoded with the right page size.

For backwards compatibility, you probably need to leave everything like so and not change your Python code. But I think the real fix, since SPM_PAGESIZE is in bytes, is to just do everything in bytes in your Python options and your description here. It's confusing, perhaps for historical reasons.